### PR TITLE
Close server gracefully

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -77,7 +77,19 @@ class Server {
             }
         }
         response._send(res, this, apiRequest);
-    };
+    }
+
+    public close(): Promise<void> {
+        return Promise.race([
+            new Promise<void>(resolve => {
+                this.server.close(() => resolve());
+            }),
+            new Promise<void>(resolve => setTimeout(() => {
+                this.server.closeAllConnections();
+                resolve();
+            }, 5000)),
+        ]);
+    }
 }
 
 namespace Server {


### PR DESCRIPTION
Calling `Server#close()` will stop accepting new connections. The server will close when the last connection ends. If the server has not closed within 5 seconds, all connections will be closed.