### PR TITLE
Ensure consistent sort order using `LC_ALL=C`

### DIFF
--- a/generateIndices.sh
+++ b/generateIndices.sh
@@ -7,7 +7,7 @@ generate_indices() {
   local index_file="$dir/index.ts"
 
   local -a ts_files
-  mapfile -t ts_files < <(find "$dir" -maxdepth 1 -type f -name "*.ts" ! -name "index.ts" | sort)
+  mapfile -t ts_files < <(find "$dir" -maxdepth 1 -type f -name "*.ts" ! -name "index.ts" | LC_ALL=C sort)
   if [[ ${#ts_files[@]} -eq 0 ]]; then
     return
   fi
@@ -22,7 +22,7 @@ generate_indices() {
   done
 
   local -a subdirs
-  mapfile -t subdirs < <(find "$dir" -mindepth 1 -maxdepth 1 -type d | sort)
+  mapfile -t subdirs < <(find "$dir" -mindepth 1 -maxdepth 1 -type d | LC_ALL=C sort)
   for subdir in "${subdirs[@]}"; do
     generate_indices "$subdir"
   done

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,3 @@ export * from "./Server.js";
 export * from "./ServerErrorRegistry.js";
 export * from "./response/index.js";
 export * from "./routing/index.js";
-// test

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./Server.js";
 export * from "./ServerErrorRegistry.js";
 export * from "./response/index.js";
 export * from "./routing/index.js";
+// test


### PR DESCRIPTION
> [!WARNING]
> The locale specified by the environment affects sort
> order. Set LC_ALL=C to get the traditional sort order that uses native
> byte values.

— `man sort`