### PR TITLE
Improve server close and listen

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -63,6 +63,8 @@ class Server extends EventEmitter<Server.Events> {
      * @param [timeout=5000] Maximum time to wait for existing connections to close before forcibly closing them.
      */
     public async close(timeout = 5000): Promise<void> {
+        if (!this.server.listening)
+            throw new Error("Server is not listening.");
         this.emit("closing");
         let timeoutId: NodeJS.Timeout;
         await Promise.race([

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -33,21 +33,21 @@ class Server extends EventEmitter<Server.Events> {
      * Create a new HTTP server.
      * @param options Server options.
      */
-    public constructor(options: Server.Options) {
+    public constructor(options?: Server.Options) {
         super();
         this.server = http.createServer({
             joinDuplicateHeaders: true,
         }, this.listener.bind(this));
 
-        this.globalHeaders = new Headers(options.globalHeaders);
+        this.globalHeaders = new Headers(options?.globalHeaders);
         if (!this.globalHeaders.has("server"))
             this.globalHeaders.set("Server", `cldn/${packageJson.version}`);
 
-        this.port = options.port;
-        this.copyOrigin = options.copyOrigin ?? false;
-        this.handleConditionalRequests = options.handleConditionalRequests ?? true;
+        this.port = options?.port;
+        this.copyOrigin = options?.copyOrigin ?? false;
+        this.handleConditionalRequests = options?.handleConditionalRequests ?? true;
 
-        if (this.port !== undefined) this.listen(this.port);
+        if (this.port !== undefined) this.listen(this.port).then();
 
         this.once("listening", () => {
             if (this.listenerCount("error") === 0)
@@ -87,10 +87,15 @@ class Server extends EventEmitter<Server.Events> {
     /**
      * Start listening for connections.
      */
-    public listen(port: number) {
+    public listen(port: number): Promise<void> {
         if (this.server.listening)
             throw new Error("Server is already listening.");
-        this.server.listen(port, process.env.HOST, () => this.emit("listening"));
+        return new Promise(resolve => {
+            this.server.listen(port, process.env.HOST, () => {
+                this.emit("listening", port, process.env.HOST);
+                resolve();
+            });
+        });
     }
 
     private async listener(req: http.IncomingMessage, res: http.ServerResponse) {
@@ -185,9 +190,9 @@ namespace Server {
     export interface Options {
         /**
          * The HTTP listener port. From 1 to 65535. Ports 1–1023 require
-         * privileges.
+         * privileges. If not set, {@link Server#listen|Server.listen()} must be called manually.
          */
-        readonly port: number;
+        readonly port?: number;
 
         /**
          * Headers to send with every response.
@@ -217,7 +222,7 @@ namespace Server {
         /**
          * Server is listening and ready to accept connections.
          */
-        listening: [void];
+        listening: [port: number, host?: string];
 
         /**
          * The server is closing and not accepting new connections.

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -58,7 +58,11 @@ class Server extends EventEmitter<Server.Events> {
         return this.server.keepAliveTimeout;
     }
 
-    public async close(): Promise<void> {
+    /**
+     * Close the server. Will stop accepting new connections and wait for existing connections to close.
+     * @param [timeout=5000] Maximum time to wait for existing connections to close before forcibly closing them.
+     */
+    public async close(timeout = 5000): Promise<void> {
         this.emit("closing");
         await Promise.race([
             new Promise<void>(resolve => {
@@ -67,7 +71,7 @@ class Server extends EventEmitter<Server.Events> {
             new Promise<void>(resolve => setTimeout(() => {
                 this.server.closeAllConnections();
                 resolve();
-            }, 5000)),
+            }, timeout)),
         ]);
         this.emit("closed");
     }

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -86,6 +86,7 @@ class Server extends EventEmitter<Server.Events> {
 
     /**
      * Start listening for connections.
+     * @param port The HTTP listener port. From 1 to 65535. Ports 1–1023 require privileges.
      */
     public listen(port: number): Promise<void> {
         if (this.server.listening)

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -25,6 +25,7 @@ class Server extends EventEmitter<Server.Events> {
      */
     public readonly errors = new ServerErrorRegistry();
     private readonly server: http.Server;
+    private readonly port?: number;
     private readonly copyOrigin: boolean;
     private readonly handleConditionalRequests: boolean;
 
@@ -42,10 +43,11 @@ class Server extends EventEmitter<Server.Events> {
         if (!this.globalHeaders.has("server"))
             this.globalHeaders.set("Server", `cldn/${packageJson.version}`);
 
+        this.port = options.port;
         this.copyOrigin = options.copyOrigin ?? false;
         this.handleConditionalRequests = options.handleConditionalRequests ?? true;
 
-        this.server.listen(options.port, process.env.HOST, () => this.emit("listening"));
+        if (this.port !== undefined) this.listen(this.port);
 
         this.once("listening", () => {
             if (this.listenerCount("error") === 0)
@@ -80,6 +82,15 @@ class Server extends EventEmitter<Server.Events> {
             }),
         ]);
         this.emit("closed");
+    }
+
+    /**
+     * Start listening for connections.
+     */
+    public listen(port: number) {
+        if (this.server.listening)
+            throw new Error("Server is already listening.");
+        this.server.listen(port, process.env.HOST, () => this.emit("listening"));
     }
 
     private async listener(req: http.IncomingMessage, res: http.ServerResponse) {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -64,14 +64,18 @@ class Server extends EventEmitter<Server.Events> {
      */
     public async close(timeout = 5000): Promise<void> {
         this.emit("closing");
+        let timeoutId: NodeJS.Timeout;
         await Promise.race([
             new Promise<void>(resolve => {
+                timeoutId = setTimeout(() => {
+                    this.server.closeAllConnections();
+                    resolve();
+                }, timeout)
+            }),
+            new Promise<void>(resolve => {
+                clearTimeout(timeoutId);
                 this.server.close(() => resolve());
             }),
-            new Promise<void>(resolve => setTimeout(() => {
-                this.server.closeAllConnections();
-                resolve();
-            }, timeout)),
         ]);
         this.emit("closed");
     }


### PR DESCRIPTION
The server will now close correctly as the forced close job will now be correctly cancelled when not needed.

Server can be restarted by calling listen()