### PR TITLE
Add ThrowableResponse

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -4,6 +4,7 @@ import packageJson from "../package.json" with {type: "json"};
 import {Request} from "./Request.js";
 import {EmptyResponse} from "./response/index.js";
 import {Response} from "./response/Response.js";
+import {ThrowableResponse} from "./response/ThrowableResponse.js";
 import {RouteRegistry} from "./routing/RouteRegistry.js";
 import {ServerErrorRegistry} from "./ServerErrorRegistry.js";
 
@@ -100,7 +101,13 @@ class Server extends EventEmitter<Server.Events> {
             response = await this.routes.handle(apiRequest);
         }
         catch (e) {
-            if (e instanceof RouteRegistry.NoRouteError)
+            if (e instanceof ThrowableResponse) {
+                response = e.getResponse();
+                const cause = e.getError();
+                if (cause !== null)
+                    this.emit("error", cause);
+            }
+            else if (e instanceof RouteRegistry.NoRouteError)
                 response = this.errors._get(ServerErrorRegistry.ErrorCodes.NO_ROUTE, apiRequest);
             else {
                 this.emit("error", e as any);

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -83,9 +83,13 @@ class Server extends EventEmitter<Server.Events> {
                 this.errors._get(ServerErrorRegistry.ErrorCodes.BAD_URL, null)._send(res, this);
                 return;
             }
+
             if (e instanceof Request.SocketClosedError)
                 return;
-            throw e;
+
+            this.emit("error", e as any);
+            this.errors._get(ServerErrorRegistry.ErrorCodes.INTERNAL, null)._send(res, this);
+            return;
         }
 
         for (const [key, value] of this.globalHeaders)

--- a/src/response/ThrowableResponse.ts
+++ b/src/response/ThrowableResponse.ts
@@ -1,0 +1,37 @@
+import {Response} from "./Response.js";
+
+/**
+ * An (error) response that is thrown. Will be caught by the server and sent to the client.
+ */
+export class ThrowableResponse<T extends Response> extends Error {
+    public override name = ThrowableResponse.name;
+
+    /**
+     * The response to send to the client.
+     */
+    protected readonly response: T;
+
+    /**
+     * An optional error to emit on the server’s error event.
+     */
+    protected readonly error: Error | null;
+
+    /**
+     * Create a new throwable response.
+     * @param response The response to send to the client.
+     * @param [error] An optional error to emit on the server’s error event.
+     */
+    public constructor(response: T, error?: Error) {
+        super();
+        this.response = response;
+        this.error = error ?? null;
+    }
+
+    public getResponse(): T {
+        return this.response;
+    }
+
+    public getError(): Error | null {
+        return this.error;
+    }
+}

--- a/src/response/index.ts
+++ b/src/response/index.ts
@@ -4,3 +4,4 @@ export * from "./EmptyResponse.js";
 export * from "./JsonResponse.js";
 export * from "./Response.js";
 export * from "./TextResponse.js";
+export * from "./ThrowableResponse.js";


### PR DESCRIPTION
Added `ThrowableResponse`, which allows a `Response` to be `throw`n within `Route#handle()`, where it will be caught by the server. This serves as an alternative to `return`ing a response—`return` can be used for success cases, while `throw` can be used for error handling. 

Additionally, on unknown failure, the request handling now returns HTTP 500 and emits the cause.