### PR TITLE
Copy package.json to dist before publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,9 @@ jobs:
         run: npm version ${{ github.event.release.tag_name }} --git-tag-version=false
 
       - name: Copy package.json to build package
-        run: cp package.json package/package
+        run: |-
+          cp package.json package/package
+          cp package.json package/package/dist
 
       - name: Publish release to NPM
         if: "!github.event.release.prerelease"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Class-based Node.js web server",
   "main": "dist/src/index.js",
   "type": "module",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/*.json"
+  ],
   "scripts": {
     "prebuild": "npm run gen:indices",
     "build": "tsc",

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "node:events";
 import http from "node:http";
-import packageJson from "../package.json" with {type: "json"};
+import packageJson from "./package.json" with {type: "json"};
 import {Authenticator} from "./auth/Authenticator.js";
 import {Request} from "./Request.js";
 import {EmptyResponse} from "./response/index.js";

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,1 @@
+../package.json


### PR DESCRIPTION
This is needed because the CI modifies the root package.json by setting release version.